### PR TITLE
chore: add manual PR preview deploy

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,27 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Remove preview folder
+        run: |
+          git rm -r --ignore-unmatch pr-${{ github.event.pull_request.number }}
+          git commit -m "chore: remove preview for PR #${{ github.event.pull_request.number }}" || echo "No changes"
+          git push origin gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,55 @@
+name: Deploy PR Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'Pull request number'
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ inputs.pr-number }}
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ inputs.pr-number }}/head
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: |
+          npm run build
+          npx next export
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          destination_dir: pr-${{ inputs.pr-number }}
+          keep_files: true
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = parseInt(process.env.PR_NUMBER, 10);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const url = `https://${owner}.github.io/${repo}/pr-${process.env.PR_NUMBER}/`;
+            await github.rest.issues.createComment({
+              issue_number: pr,
+              owner,
+              repo,
+              body: `Preview deployed: ${url}`
+            });


### PR DESCRIPTION
## Summary
- add manual workflow to deploy PRs to gh-pages subdirectories and comment link
- cleanup preview directories when PRs merge

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: configuration prompt)
- `npm run format` (fails: Missing script: "format")

------
https://chatgpt.com/codex/tasks/task_e_68c1367a77d48320b1e81ad57719fd65