### PR TITLE
fix: improve chart colors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Progress } from "@/components/ui/progress"
-import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
 import {
   BarChart,
   Bar,
@@ -19,7 +19,7 @@ import {
   Cell,
   AreaChart,
   Area,
-} from "recharts"
+} from "recharts";
 import {
   FileText,
   Clock,
@@ -32,8 +32,8 @@ import {
   AlertTriangle,
   RefreshCw,
   Settings,
-} from "lucide-react"
-import { useState, useEffect } from "react"
+} from "lucide-react";
+import { useState, useEffect } from "react";
 
 // Mock data for the dashboard
 const queueData = [
@@ -44,7 +44,7 @@ const queueData = [
   { name: "Fri", pending: 43, processing: 11, completed: 87, failed: 4 },
   { name: "Sat", pending: 29, processing: 6, completed: 65, failed: 2 },
   { name: "Sun", pending: 35, processing: 7, completed: 71, failed: 3 },
-]
+];
 
 const tokenUsageData = [
   { time: "00:00", input: 1200, output: 800 },
@@ -53,14 +53,14 @@ const tokenUsageData = [
   { time: "12:00", input: 3200, output: 2100 },
   { time: "16:00", input: 2800, output: 1900 },
   { time: "20:00", input: 2200, output: 1500 },
-]
+];
 
 const processingStages = [
-  { name: "Ingestion", value: 25, color: "hsl(var(--chart-1))" },
-  { name: "Chunking", value: 20, color: "hsl(var(--chart-2))" },
-  { name: "Embedding", value: 30, color: "hsl(var(--chart-3))" },
-  { name: "Indexing", value: 25, color: "hsl(var(--chart-4))" },
-]
+  { name: "Ingestion", value: 25, color: "var(--chart-1)" },
+  { name: "Chunking", value: 20, color: "var(--chart-2)" },
+  { name: "Embedding", value: 30, color: "var(--chart-3)" },
+  { name: "Indexing", value: 25, color: "var(--chart-4)" },
+];
 
 const requestMetrics = [
   { time: "00:00", requests: 45, latency: 120 },
@@ -69,21 +69,21 @@ const requestMetrics = [
   { time: "12:00", requests: 95, latency: 160 },
   { time: "16:00", requests: 87, latency: 135 },
   { time: "20:00", requests: 62, latency: 110 },
-]
+];
 
 export default function RAGDashboard() {
-  const [currentTime, setCurrentTime] = useState(new Date())
-  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [currentTime, setCurrentTime] = useState(new Date());
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   useEffect(() => {
-    const timer = setInterval(() => setCurrentTime(new Date()), 1000)
-    return () => clearInterval(timer)
-  }, [])
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
 
   const handleRefresh = () => {
-    setIsRefreshing(true)
-    setTimeout(() => setIsRefreshing(false), 2000)
-  }
+    setIsRefreshing(true);
+    setTimeout(() => setIsRefreshing(false), 2000);
+  };
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -100,9 +100,18 @@ export default function RAGDashboard() {
             </Badge>
           </div>
           <div className="flex items-center space-x-4">
-            <span className="text-sm text-muted-foreground">{currentTime.toLocaleTimeString()}</span>
-            <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isRefreshing}>
-              <RefreshCw className={`h-4 w-4 mr-2 ${isRefreshing ? "animate-spin" : ""}`} />
+            <span className="text-sm text-muted-foreground">
+              {currentTime.toLocaleTimeString()}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              <RefreshCw
+                className={`h-4 w-4 mr-2 ${isRefreshing ? "animate-spin" : ""}`}
+              />
               Refresh
             </Button>
             <Button variant="outline" size="sm">
@@ -118,7 +127,9 @@ export default function RAGDashboard() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Documents in Queue</CardTitle>
+              <CardTitle className="text-sm font-medium">
+                Documents in Queue
+              </CardTitle>
               <FileText className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
@@ -132,7 +143,9 @@ export default function RAGDashboard() {
 
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Processing Rate</CardTitle>
+              <CardTitle className="text-sm font-medium">
+                Processing Rate
+              </CardTitle>
               <Activity className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
@@ -160,7 +173,9 @@ export default function RAGDashboard() {
 
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Active Requests</CardTitle>
+              <CardTitle className="text-sm font-medium">
+                Active Requests
+              </CardTitle>
               <Users className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
@@ -182,20 +197,20 @@ export default function RAGDashboard() {
             <CardContent>
               <ResponsiveContainer width="100%" height={300}>
                 <BarChart data={queueData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                  <XAxis dataKey="name" stroke="hsl(var(--muted-foreground))" />
-                  <YAxis stroke="hsl(var(--muted-foreground))" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                  <XAxis dataKey="name" stroke="var(--muted-foreground)" />
+                  <YAxis stroke="var(--muted-foreground)" />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "hsl(var(--card))",
-                      border: "1px solid hsl(var(--border))",
+                      backgroundColor: "var(--card)",
+                      border: "1px solid var(--border)",
                       borderRadius: "6px",
                     }}
                   />
-                  <Bar dataKey="pending" stackId="a" fill="hsl(var(--chart-2))" />
-                  <Bar dataKey="processing" stackId="a" fill="hsl(var(--chart-5))" />
-                  <Bar dataKey="completed" stackId="a" fill="hsl(var(--chart-1))" />
-                  <Bar dataKey="failed" stackId="a" fill="hsl(var(--chart-3))" />
+                  <Bar dataKey="pending" stackId="a" fill="var(--chart-2)" />
+                  <Bar dataKey="processing" stackId="a" fill="var(--chart-5)" />
+                  <Bar dataKey="completed" stackId="a" fill="var(--chart-1)" />
+                  <Bar dataKey="failed" stackId="a" fill="var(--chart-3)" />
                 </BarChart>
               </ResponsiveContainer>
             </CardContent>
@@ -209,13 +224,13 @@ export default function RAGDashboard() {
             <CardContent>
               <ResponsiveContainer width="100%" height={300}>
                 <AreaChart data={tokenUsageData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                  <XAxis dataKey="time" stroke="hsl(var(--muted-foreground))" />
-                  <YAxis stroke="hsl(var(--muted-foreground))" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                  <XAxis dataKey="time" stroke="var(--muted-foreground)" />
+                  <YAxis stroke="var(--muted-foreground)" />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "hsl(var(--card))",
-                      border: "1px solid hsl(var(--border))",
+                      backgroundColor: "var(--card)",
+                      border: "1px solid var(--border)",
                       borderRadius: "6px",
                     }}
                   />
@@ -223,16 +238,16 @@ export default function RAGDashboard() {
                     type="monotone"
                     dataKey="input"
                     stackId="1"
-                    stroke="hsl(var(--chart-1))"
-                    fill="hsl(var(--chart-1))"
+                    stroke="var(--chart-1)"
+                    fill="var(--chart-1)"
                     fillOpacity={0.6}
                   />
                   <Area
                     type="monotone"
                     dataKey="output"
                     stackId="1"
-                    stroke="hsl(var(--chart-5))"
-                    fill="hsl(var(--chart-5))"
+                    stroke="var(--chart-5)"
+                    fill="var(--chart-5)"
                     fillOpacity={0.6}
                   />
                 </AreaChart>
@@ -266,8 +281,8 @@ export default function RAGDashboard() {
                   </Pie>
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "hsl(var(--card))",
-                      border: "1px solid hsl(var(--border))",
+                      backgroundColor: "var(--card)",
+                      border: "1px solid var(--border)",
                       borderRadius: "6px",
                     }}
                   />
@@ -275,9 +290,15 @@ export default function RAGDashboard() {
               </ResponsiveContainer>
               <div className="mt-4 space-y-2">
                 {processingStages.map((stage, index) => (
-                  <div key={index} className="flex items-center justify-between">
+                  <div
+                    key={index}
+                    className="flex items-center justify-between"
+                  >
                     <div className="flex items-center space-x-2">
-                      <div className="w-3 h-3 rounded-full" style={{ backgroundColor: stage.color }} />
+                      <div
+                        className="w-3 h-3 rounded-full"
+                        style={{ backgroundColor: stage.color }}
+                      />
                       <span className="text-sm">{stage.name}</span>
                     </div>
                     <span className="text-sm font-medium">{stage.value}%</span>
@@ -295,14 +316,18 @@ export default function RAGDashboard() {
             <CardContent>
               <ResponsiveContainer width="100%" height={250}>
                 <LineChart data={requestMetrics}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                  <XAxis dataKey="time" stroke="hsl(var(--muted-foreground))" />
-                  <YAxis yAxisId="left" stroke="hsl(var(--muted-foreground))" />
-                  <YAxis yAxisId="right" orientation="right" stroke="hsl(var(--muted-foreground))" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                  <XAxis dataKey="time" stroke="var(--muted-foreground)" />
+                  <YAxis yAxisId="left" stroke="var(--muted-foreground)" />
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    stroke="var(--muted-foreground)"
+                  />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "hsl(var(--card))",
-                      border: "1px solid hsl(var(--border))",
+                      backgroundColor: "var(--card)",
+                      border: "1px solid var(--border)",
                       borderRadius: "6px",
                     }}
                   />
@@ -310,17 +335,17 @@ export default function RAGDashboard() {
                     yAxisId="left"
                     type="monotone"
                     dataKey="requests"
-                    stroke="hsl(var(--chart-1))"
+                    stroke="var(--chart-1)"
                     strokeWidth={2}
-                    dot={{ fill: "hsl(var(--chart-1))" }}
+                    dot={{ fill: "var(--chart-1)" }}
                   />
                   <Line
                     yAxisId="right"
                     type="monotone"
                     dataKey="latency"
-                    stroke="hsl(var(--chart-3))"
+                    stroke="var(--chart-3)"
                     strokeWidth={2}
-                    dot={{ fill: "hsl(var(--chart-3))" }}
+                    dot={{ fill: "var(--chart-3)" }}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -361,5 +386,5 @@ export default function RAGDashboard() {
         </Card>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- use theme variables directly for chart colors to ensure visibility

## Testing
- `npm run lint` (fails: How would you like to configure ESLint? https://nextjs.org/docs/basic-features/eslint)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c135f8fd648320a3885d3190f884d7