### PR TITLE
Fix PR preview deployment for Next.js site

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       pr-number:
-        description: 'Pull request number'
+        description: "Pull request number"
         required: true
         type: number
 
@@ -26,11 +26,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          static_site_generator: next
       - name: Install dependencies
         run: npm ci
-      - name: Build site
-        run: |
-          npm run build
+      - name: Build & export site
+        env:
+          NEXT_PUBLIC_BASE_PATH: pr-${{ inputs.pr-number }}
+        run: npm run build && npx next export
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,19 @@
 /** @type {import('next').NextConfig} */
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
 const nextConfig = {
+  output: "export",
+  basePath,
+  assetPrefix: basePath,
+  images: {
+    unoptimized: true,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },
   typescript: {
     ignoreBuildErrors: true,
   },
-  images: {
-    unoptimized: true,
-  },
-}
+};
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
## Summary
- export static site with configurable basePath for PR previews
- configure PR preview workflow to build and deploy exported output

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm test` *(fails: Missing script "test"`)*

------
https://chatgpt.com/codex/tasks/task_e_68c13c359e688320923fc3e56cb99318