### PR TITLE
Remove Settings button from header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,6 @@ import {
   TrendingUp,
   AlertTriangle,
   RefreshCw,
-  Settings,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 
@@ -113,10 +112,6 @@ export default function RAGDashboard() {
                 className={`h-4 w-4 mr-2 ${isRefreshing ? "animate-spin" : ""}`}
               />
               Refresh
-            </Button>
-            <Button variant="outline" size="sm">
-              <Settings className="h-4 w-4 mr-2" />
-              Settings
             </Button>
           </div>
         </div>


### PR DESCRIPTION
- Summary
      - Remove the non-functional Settings button from the header to declutter the UI; drop unused Settings icon import.
  - Rationale
      - The button had no behavior and could confuse users. This simplifies the header without impacting functionality.
  - Changes
      - app/page.tsx: remove Settings button; remove Settings from lucide-react import.
  - QA
      - Lint: passed (npm run lint)
      - Type check: passed (npx tsc --noEmit)
      - No runtime logic changed; refresh functionality unchanged.